### PR TITLE
Only set duration option to INDEFINITE when an action callback/label are...

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -32,6 +32,16 @@ var SnackbarAndroid = {
       options = {};
     }
 
+    var label, callback;
+    if (options.actionLabel && options.actionCallback) {
+      if (options.duration == null) {
+        options.duration = this.INDEFINITE;
+      }
+
+      label = options.actionLabel;
+      callback = options.actionCallback;
+    }
+
     if (options.duration == null) {
       options.duration = this.SHORT;
     }
@@ -44,13 +54,6 @@ var SnackbarAndroid = {
       options.actionColor = '#EEFF41';
     }
     var color = React.processColor(options.actionColor);
-
-    var label, callback;
-    if (options.actionLabel && options.actionCallback) {
-      options.duration = this.INDEFINITE;
-      label = options.actionLabel;
-      callback = options.actionCallback;
-    }
 
     this.snackbar = NativeSnackbar.show(
       message,


### PR DESCRIPTION
...supplied if the user hasn't already provided a duration value.

Hi again, I noticed that if I provide a duration _and_ an action callback/label, the duration I specified was being overridden to `LENGTH_INDEFINITE`, so I changed the JS so that it only sets it to `INDEFINITE` if the user didn't already specify a duration in the options.
