### PR TITLE
Fix issue with snackbar position

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Available options:
 
 [Check full example](Example/index.android.js).
 
+To dismiss the currently active Snackbar early (for example, when changing scenes in your app), you can call:
+
+```js
+Snackbar.dismiss();
+```
 
 ## Setup
 

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 
 public class ReactSnackbarModule extends ReactContextBaseJavaModule {
   private View mRootView = null;
+  private Snackbar mSnackbar = null;
 
   private static final String LENGTH_SHORT = "SHORT";
   private static final String LENGTH_LONG = "LONG";
@@ -47,35 +48,45 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void show(String message, int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
-    final Snackbar snackbar = Snackbar.make(mRootView, message, length);
+    mSnackbar = Snackbar.make(mRootView, message, length);
 
     // enforce snackbar background/text color so it doesn't inherit from styles.xml
-    View snackbarView = snackbar.getView();
+    View snackbarView = mSnackbar.getView();
     snackbarView.setBackgroundColor(COLOR_BACKGROUND);
     TextView textView = (TextView) snackbarView.findViewById(R.id.snackbar_text);
     textView.setTextColor(COLOR_TEXT);
 
     // set a custom action color
-    snackbar.setActionTextColor(actionColor);
+    mSnackbar.setActionTextColor(actionColor);
 
     if (hideOnClick) {
-      snackbar.setAction("Dismiss", new View.OnClickListener() {
+      mSnackbar.setAction("Dismiss", new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-          snackbar.dismiss();
+          mSnackbar.dismiss();
         }
       });
     }
     else if (actionLabel != null && actionCallback != null) {
-      snackbar.setAction(actionLabel, new View.OnClickListener() {
+      mSnackbar.setAction(actionLabel, new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-          snackbar.dismiss();
+          mSnackbar.dismiss();
           actionCallback.invoke();
         }
       });
     }
 
-    snackbar.show();
+    mSnackbar.show();
+  }
+
+  @ReactMethod
+  public void dismiss() {
+    if (mSnackbar == null) {
+      return;
+    }
+
+    mSnackbar.dismiss();
+    mSnackbar = null;
   }
 }

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class ReactSnackbarModule extends ReactContextBaseJavaModule {
-  private View mRootView = null;
+  private Activity mActivity = null;
   private Snackbar mSnackbar = null;
 
   private static final String LENGTH_SHORT = "SHORT";
@@ -29,7 +29,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
 
   public ReactSnackbarModule(ReactApplicationContext reactContext, Activity activity) {
     super(reactContext);
-    mRootView = activity.getWindow().getDecorView().getRootView();
+    mActivity = activity;
   }
 
   @Override
@@ -48,7 +48,8 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void show(String message, int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
-    mSnackbar = Snackbar.make(mRootView, message, length);
+    View view = mActivity.findViewById(android.R.id.content);
+    mSnackbar = Snackbar.make(view, message, length);
 
     // enforce snackbar background/text color so it doesn't inherit from styles.xml
     View snackbarView = mSnackbar.getView();

--- a/index.android.js
+++ b/index.android.js
@@ -59,6 +59,10 @@ var SnackbarAndroid = {
       color,
       label,
       callback);
+  },
+
+  dismiss: function(): void {
+    NativeSnackbar.dismiss();
   }
 };
 

--- a/index.android.js
+++ b/index.android.js
@@ -8,8 +8,9 @@
  * This exposes the native SnackbarAndroid module in JS.
  */
 
-var React = require('react-native');
-var NativeSnackbar = React.NativeModules.SnackbarAndroid;
+import { NativeModules, processColor } from 'react-native';
+
+var NativeSnackbar = NativeModules.SnackbarAndroid;
 
 var SnackbarAndroid = {
   SHORT:       NativeSnackbar.SHORT,
@@ -53,7 +54,7 @@ var SnackbarAndroid = {
     if (options.actionColor == null) {
       options.actionColor = '#EEFF41';
     }
-    var color = React.processColor(options.actionColor);
+    var color = processColor(options.actionColor);
 
     this.snackbar = NativeSnackbar.show(
       message,


### PR DESCRIPTION
## Description

As we need to be able to display the snackbar above the system buttons,
this code will achieve it by changing the way that we get the actual
content space of the current view on the screen.

I've test this on emulator devices with OS 4.3 and in my physical device OS 6.0.
## Media

![fullscreen_6_14_16__2_28_pm](https://cloud.githubusercontent.com/assets/1425162/16056747/8a35d99c-323c-11e6-86c0-e5297cdac15b.jpg)
