### PR TITLE
Compatability with RN 0.29, also adding backward compatibility for apps using less than 0.29 version to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ public class MainActivity extends ReactActivity {
   protected List<ReactPackage> getPackages() {
     return Arrays.<ReactPackage>asList(
       new MainReactPackage(),
-      new ReactSnackbarPackage(this) // Add the package here
+      new ReactSnackbarPackage() // Add the package here
     );
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.13.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:design:23.0.1'
 }

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class ReactSnackbarModule extends ReactContextBaseJavaModule {
-  private Activity mActivity = null;
   private Snackbar mSnackbar = null;
 
   private static final String LENGTH_SHORT = "SHORT";
@@ -27,9 +26,8 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
   private static final int COLOR_BACKGROUND = -13487566; // #323232
   private static final int COLOR_TEXT = Color.WHITE;
 
-  public ReactSnackbarModule(ReactApplicationContext reactContext, Activity activity) {
+  public ReactSnackbarModule(ReactApplicationContext reactContext) {
     super(reactContext);
-    mActivity = activity;
   }
 
   @Override
@@ -48,7 +46,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void show(String message, int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
-    View view = mActivity.findViewById(android.R.id.content);
+    View view = getCurrentActivity().findViewById(android.R.id.content);
     mSnackbar = Snackbar.make(view, message, length);
 
     // enforce snackbar background/text color so it doesn't inherit from styles.xml

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarPackage.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarPackage.java
@@ -15,14 +15,17 @@ import java.util.List;
 public class ReactSnackbarPackage implements ReactPackage {
     private Activity mActivity = null;
 
+    public ReactSnackbarPackage() {
+    }
+
     public ReactSnackbarPackage(Activity activity) {
-        mActivity = activity;
+        this();
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-            new ReactSnackbarModule(reactContext, mActivity)
+            new ReactSnackbarModule(reactContext)
         );
     }
 


### PR DESCRIPTION
The existing plugin won't work for 0.29 version of React Native.This is for making the plugin work with latest react native version (0.29+), refer to the breaking changes section of 0.29 for the changes - [here](https://github.com/facebook/react-native/releases/tag/v0.29.0).

Now the user has to just import the plugin as `new ReactSnackbarPackage()`.
