### PR TITLE
Updates for React Native 0.29 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ dependencies {
 }
 ```
 
-3. Change your main activity to add a new package, in `android/app/src/main/.../MainActivity.java`:
+3. Change your main application to add a new package, in `android/app/src/main/.../MainApplication.java`:
 
 ```java
 import com.lugg.ReactSnackbar.ReactSnackbarPackage; // Add new import
 
-public class MainActivity extends ReactActivity {
+public class MainApplication extends Application implements ReactApplication {
   ...
   
   @Override
   protected List<ReactPackage> getPackages() {
     return Arrays.<ReactPackage>asList(
       new MainReactPackage(),
-      new ReactSnackbarPackage(this) // Add the package here
+      new ReactSnackbarPackage() // Add the package here
     );
   }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.13.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:design:23.0.1'
 }

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import java.util.HashMap;
 
 public class ReactSnackbarModule extends ReactContextBaseJavaModule {
-  private Activity mActivity = null;
   private Snackbar mSnackbar = null;
 
   private static final String LENGTH_SHORT = "SHORT";
@@ -27,9 +26,8 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
   private static final int COLOR_BACKGROUND = -13487566; // #323232
   private static final int COLOR_TEXT = Color.WHITE;
 
-  public ReactSnackbarModule(ReactApplicationContext reactContext, Activity activity) {
+  public ReactSnackbarModule(ReactApplicationContext reactContext) {
     super(reactContext);
-    mActivity = activity;
   }
 
   @Override
@@ -48,7 +46,11 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void show(String message, int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
-    View view = mActivity.findViewById(android.R.id.content);
+    final Activity activity = getCurrentActivity();
+
+    if (activity == null) return;
+
+    View view = activity.findViewById(android.R.id.content);
     mSnackbar = Snackbar.make(view, message, length);
 
     // enforce snackbar background/text color so it doesn't inherit from styles.xml

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -1,17 +1,21 @@
 package com.lugg.ReactSnackbar;
 
 import android.app.Activity;
-import android.view.View;
 import android.graphics.Color;
-import android.widget.TextView;
+import android.os.Handler;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
+import android.view.View;
+import android.widget.TextView;
 
+import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.WritableMap;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -23,11 +27,68 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
   private static final String LENGTH_LONG = "LONG";
   private static final String LENGTH_INDEFINITE = "INDEFINITE";
 
+  // Events which will be posted to the JS module
+  private static final String EVENT_HIDE = "snackbarHide";
+  private static final String EVENT_HIDDEN = "snackbarHidden";
+  private static final String EVENT_SHOW = "snackbarShow";
+  private static final String EVENT_SHOWN = "snackbarShown";
+
+  /**
+   * @hack
+   *
+   * Durations of animations and show constants.
+   *
+   * Taken from Android source code.  This sucks because if they change, we'll
+   * have to update these.  Unfortunately there doesn't seem to be anyway to get
+   * these values programmatically.
+   *
+   * https://github.com/android/platform_frameworks_support/blob/62eb3105e51335cf9074a5506d8d2b220aeb95dc/design/src/android/support/design/widget/Snackbar.java
+   */
+  private static final int ANIMATION_DURATION = 250;
+  private static final int ANIMATION_FADE_DURATION = 180;
+  private static final int DURATION_SHORT_MS = 1500;
+  private static final int DURATION_LONG_MS = 2750;
+
   private static final int COLOR_BACKGROUND = -13487566; // #323232
   private static final int COLOR_TEXT = Color.WHITE;
 
+  private ReactContext mContext;
+
   public ReactSnackbarModule(ReactApplicationContext reactContext) {
     super(reactContext);
+
+    mContext = reactContext;
+  }
+
+  /**
+   * Delivers an event to the JS module.
+   *
+   * @param eventType the event type, such the constant EVENT_SHOW
+   * @param params map of event parameters that the JS will receive
+   */
+  private void sendEvent(String eventType, @Nullable WritableMap params) {
+    mContext
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+      .emit(eventType, params);
+  }
+
+  /**
+   * Sends EVENT_HIDE to the JS module after the specified delay
+   *
+   * @param delayMs delay before sending EVENT_HIDE, in ms
+   */
+  private void setupDelayedHideEvent(int delayMs) {
+    final Handler handler = new Handler();
+    handler.postDelayed(new Runnable() {
+      @Override
+      public void run() {
+
+        // If Snackbar is not already dismissed, fire EVENT_HIDE
+        if (mSnackbar.isShown()) {
+          ReactSnackbarModule.this.sendEvent(EVENT_HIDE, null);
+        }
+      }
+    }, delayMs);
   }
 
   @Override
@@ -41,11 +102,17 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
     constants.put(LENGTH_SHORT, Snackbar.LENGTH_SHORT);
     constants.put(LENGTH_LONG, Snackbar.LENGTH_LONG);
     constants.put(LENGTH_INDEFINITE, Snackbar.LENGTH_INDEFINITE);
+    constants.put("EVENT_HIDE", EVENT_HIDE);
+    constants.put("EVENT_HIDDEN", EVENT_HIDDEN);
+    constants.put("EVENT_SHOW", EVENT_SHOW);
+    constants.put("EVENT_SHOWN", EVENT_SHOWN);
+    constants.put("ANIMATION_DURATION", ANIMATION_DURATION);
+    constants.put("ANIMATION_FADE_DURATION", ANIMATION_FADE_DURATION);
     return constants;
   }
 
   @ReactMethod
-  public void show(String message, int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
+  public void show(String message, final int length, boolean hideOnClick, int actionColor, String actionLabel, final Callback actionCallback) {
     final Activity activity = getCurrentActivity();
 
     if (activity == null) return;
@@ -53,11 +120,57 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
     View view = activity.findViewById(android.R.id.content);
     mSnackbar = Snackbar.make(view, message, length);
 
+    mSnackbar.setCallback(new Snackbar.Callback() {
+      /**
+       * When the Snackbar is hidden, fire EVENT_HIDDEN to the JS module
+       * @todo send event in params
+       *
+       * @param snackbar the snackbar which was hidden
+       * @param event    one of the Snackbar's event type constants
+       */
+      public void onDismissed(Snackbar snackbar, int event) {
+        ReactSnackbarModule.this.sendEvent(EVENT_HIDDEN, null);
+      }
+
+      /**
+       * When the Snackbar is shown, fire EVENT_SHOWN to the JS module
+       */
+      public void onShown(Snackbar snackbar) {
+        ReactSnackbarModule.this.sendEvent(EVENT_SHOWN, null);
+
+        /* Setup a delay for firing EVENT_HIDE after the specified show duration
+         * expires, provided the length is not LENGTH_INDEFINITE (-2) */
+        if (length > Snackbar.LENGTH_INDEFINITE) {
+          switch (length) {
+            case Snackbar.LENGTH_SHORT:
+              setupDelayedHideEvent(DURATION_SHORT_MS);
+              break;
+            case Snackbar.LENGTH_LONG:
+              setupDelayedHideEvent(DURATION_LONG_MS);
+              break;
+            default:
+              setupDelayedHideEvent(length);
+          }
+        }
+      }
+    });
+
     // enforce snackbar background/text color so it doesn't inherit from styles.xml
     View snackbarView = mSnackbar.getView();
     snackbarView.setBackgroundColor(COLOR_BACKGROUND);
     TextView textView = (TextView) snackbarView.findViewById(R.id.snackbar_text);
     textView.setTextColor(COLOR_TEXT);
+
+    // Add a state change listener for firing EVENT_SHOW
+    snackbarView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+      @Override
+      public void onViewAttachedToWindow(View v) {
+        ReactSnackbarModule.this.sendEvent(EVENT_SHOW, null);
+      }
+
+      @Override
+      public void onViewDetachedFromWindow(View v) { }
+    });
 
     // set a custom action color
     mSnackbar.setActionTextColor(actionColor);
@@ -66,7 +179,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
       mSnackbar.setAction("Dismiss", new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-          mSnackbar.dismiss();
+          ReactSnackbarModule.this.dismiss();
         }
       });
     }
@@ -74,7 +187,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
       mSnackbar.setAction(actionLabel, new View.OnClickListener() {
         @Override
         public void onClick(View v) {
-          mSnackbar.dismiss();
+          ReactSnackbarModule.this.dismiss();
           actionCallback.invoke();
         }
       });
@@ -89,6 +202,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
       return;
     }
 
+    sendEvent(EVENT_HIDE, null);
     mSnackbar.dismiss();
     mSnackbar = null;
   }

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarModule.java
@@ -84,7 +84,7 @@ public class ReactSnackbarModule extends ReactContextBaseJavaModule {
       public void run() {
 
         // If Snackbar is not already dismissed, fire EVENT_HIDE
-        if (mSnackbar.isShown()) {
+        if (mSnackbar != null && mSnackbar.isShown()) {
           ReactSnackbarModule.this.sendEvent(EVENT_HIDE, null);
         }
       }

--- a/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarPackage.java
+++ b/android/src/main/java/com/lugg/ReactSnackbar/ReactSnackbarPackage.java
@@ -1,7 +1,5 @@
 package com.lugg.ReactSnackbar;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -13,16 +11,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class ReactSnackbarPackage implements ReactPackage {
-    private Activity mActivity = null;
-
-    public ReactSnackbarPackage(Activity activity) {
-        mActivity = activity;
-    }
-
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-            new ReactSnackbarModule(reactContext, mActivity)
+            new ReactSnackbarModule(reactContext)
         );
     }
 

--- a/index.android.js
+++ b/index.android.js
@@ -8,14 +8,27 @@
  * This exposes the native SnackbarAndroid module in JS.
  */
 
-import { NativeModules, processColor } from 'react-native';
+import { DeviceEventEmitter, NativeModules, processColor } from 'react-native';
 
 var NativeSnackbar = NativeModules.SnackbarAndroid;
+
+// List of registered event listeners
+var eventListeners = {}
+
+// Map of event names for consumers to names delivered by native module
+var eventListenerMap = {
+  hide: NativeSnackbar.EVENT_HIDE,
+  hidden: NativeSnackbar.EVENT_HIDDEN,
+  show: NativeSnackbar.EVENT_SHOW,
+  shown: NativeSnackbar.EVENT_SHOWN
+}
 
 var SnackbarAndroid = {
   SHORT:       NativeSnackbar.SHORT,
   LONG:        NativeSnackbar.LONG,
   INDEFINITE:  NativeSnackbar.INDEFINITE,
+  ANIMATION_DURATION: NativeSnackbar.ANIMATION_DURATION,
+  ANIMATION_FADE_DURATION: NativeSnackbar.ANIMATION_FADE_DURATION,
   UNTIL_CLICK: 42,
 
   show: function (
@@ -67,6 +80,38 @@ var SnackbarAndroid = {
 
   dismiss: function(): void {
     NativeSnackbar.dismiss();
+  },
+
+  /**
+   * Add an event listener for the specified event type
+   *
+   * @param {String} eventType   one of 'hide', 'show', 'hidden' or 'shown'
+   * @param {Function} callback  callback to execute when event is received
+   */
+  addEventListener(eventType: string, callback: Function): void {
+    if (eventType in eventListenerMap) {
+      eventListeners[callback] = DeviceEventEmitter.addListener(
+        eventListenerMap[eventType],
+        callback
+      );
+    }
+  },
+
+  /**
+   * Removes a previously registered event listener for the specified type.
+   *
+   * @param {String} eventType   type of event that callback was registered to
+   * @param {Function} callback  listener to remove. Must be the same object
+   *                             reference as the function that was originally
+   *                             passed to addEventListener()
+   */
+  removeEventListener(eventType: string, callback: Function): void {
+    if (eventType in eventListenerMap) {
+      if (callback in eventListeners) {
+        DeviceEventEmitter.removeSubscription(eventListeners[callback]);
+        delete eventListeners[callback];
+      }
+    }
   }
 };
 


### PR DESCRIPTION
Use getCurrentActivity() instead of passing Activity instance through
constructors.

Update README accordingly.

Fixes #14
